### PR TITLE
Fix broken doc links and update docs for .NET 10

### DIFF
--- a/Docs/Layouts/Building a Layout.md
+++ b/Docs/Layouts/Building a Layout.md
@@ -7,7 +7,7 @@ This guide will walk you through the process of creating your own layout for the
 ### 1. Prerequisites
 
 - Basic knowledge of C# and XAML (Avalonia UI)
-- .NET SDK installed
+- .NET 10 SDK installed
 
 ### 2. Project Setup
 
@@ -34,10 +34,10 @@ This guide will walk you through the process of creating your own layout for the
     }
    ```
 
-4. In the `SimpleLayout.csproj` file make sure the `TargetFramework` is `net8.0`
+4. In the `SimpleLayout.csproj` file make sure the `TargetFramework` is `net10.0`
 
    ```xml
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
    ```
 
 5. In the `SimpleLayout.csproj` file add a `TargetExt` field below the `TargetFramework` line

--- a/Docs/Layouts/Building a Layout.md
+++ b/Docs/Layouts/Building a Layout.md
@@ -1,6 +1,6 @@
 # Building a Layout for nsquared dashboard
 
-This guide will walk you through the process of creating your own layout for the nsquared dashboard, using the [`SimpleLayout` project](https://github.com/nsquaredsolutions/dashboard/tree/main//Samples/SimpleLayout) as a reference. Follow these steps to build a layout from scratch.
+This guide will walk you through the process of creating your own layout for the nsquared dashboard, using the [`SimpleLayout` project](https://github.com/nsquaredsolutions/dashboard/tree/main/Samples/SimpleLayout) as a reference. Follow these steps to build a layout from scratch.
 
 ## Outline
 
@@ -224,7 +224,7 @@ The new layout should now be displayed in the dashboard.
 
 ### 8. Tips and Best Practices
 
-- Use the [SimpleLayout project](https://github.com/nsquaredsolutions/dashboard/tree/main//Samples/SimpleLayout) as a reference
+- Use the [SimpleLayout project](https://github.com/nsquaredsolutions/dashboard/tree/main/Samples/SimpleLayout) as a reference
 
 - Keep components modular and reusable
 

--- a/Docs/Layouts/Index.md
+++ b/Docs/Layouts/Index.md
@@ -17,4 +17,4 @@ The layouts on this page have been built by nsquared and digitally signed so you
 > Note: to see the clocks in the world map you will need to install the [Clocks component](../Components/Index.md)
 
 
-[Information on creating your own layouts](./Building%20a%20Layout)
+[Information on creating your own layouts](./Building%20a%20Layout.md)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Layout files can be added. You can download layouts (.layout) files and add them
 
 > [Layouts available to download](./Docs/Layouts/Index.md)
 
-> [Information on creating your own layouts](./Docs/Layouts/Building%20a%20Layout)
+> [Information on creating your own layouts](./Docs/Layouts/Building%20a%20Layout.md)
 
 ---
 

--- a/Samples/SimpleLayout/SimpleLayout.csproj
+++ b/Samples/SimpleLayout/SimpleLayout.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TargetExt>.Layout</TargetExt>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="nsquared.dashboard.api" Version="0.0.146.12420-alpha" />
+    <PackageReference Include="Avalonia" Version="11.3.18" />
+    <PackageReference Include="nsquared.dashboard.api" Version="0.0.164.21576-alpha" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The documentation had several broken links and was still referencing .NET 8, which no longer matches the current version of the dashboard.

## What changed

**Broken links fixed:**
- Corrected double slash (`main//Samples`) in two GitHub URLs in `Building a Layout.md`
- Added missing `.md` extension to the "Building a Layout" links in `README.md` and `Layouts/Index.md`

**Updated for .NET 10:**
- Prerequisites in `Building a Layout.md` now specify the .NET 10 SDK
- Step 4 description and `<TargetFramework>` snippet updated from `net8.0` to `net10.0`
- `Samples/SimpleLayout/SimpleLayout.csproj` updated: target framework to `net10.0`, Avalonia from `11.2.3` to `11.3.18`, and `nsquared.dashboard.api` from `0.0.146.12420-alpha` to `0.0.164.21576-alpha`

The `ILayout` and `IComponent` API interfaces are unchanged across package versions, so no code sample logic required updating.